### PR TITLE
Remove now-illegal whitespace from macro names

### DIFF
--- a/config/client_macros.cfg
+++ b/config/client_macros.cfg
@@ -1,5 +1,5 @@
 
-[gcode_macro START_PRINT T_BED T_EXTRUDER]
+[gcode_macro START_PRINT]
 variable_parameter_T_BED: 60
 variable_parameter_T_EXTRUDER: 215
 gcode:
@@ -132,7 +132,7 @@ gcode:
 # - If this setpoint is reached, continue. 
 # - If not, heat to setpoint.
 # - If no setpoint, heat to parameter T (default@200)
-[gcode_macro LOW_TEMP_CHECK T]
+[gcode_macro LOW_TEMP_CHECK]
 default_parameter_T: 215
 gcode: 
     {% if printer.extruder.target != 0 %} # if there is a setpoint for extruder


### PR DESCRIPTION
See https://github.com/KevinOConnor/klipper/pull/4312
Listing the parameters in the macro definition isn't necessary