### PR TITLE
Align with printer data folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # klipper-web-control-docker
 
-## Caution
+__Caution__
 If you used klipper-web-control-docker before, mind the changes in `docker-compose.yml` in accordance with the changed [moonraker standard](https://moonraker.readthedocs.io/en/latest/installation/#data-folder-structure).
 Volume bindings were changed from `gcode_files:/home/klippy/gcode_files` to `gcodes:/home/klippy/printer_data/gcodes` and from `./config:/home/klippy/.config` to `./config:/home/klippy/printer_data/config`. `moonraker_data:/home/klippy/.moonraker` was removed.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 # klipper-web-control-docker
 
 __Caution__
+
 If you used klipper-web-control-docker before, mind the changes in `docker-compose.yml` in accordance with the changed [moonraker standard](https://moonraker.readthedocs.io/en/latest/installation/#data-folder-structure).
 Volume bindings were changed from `gcode_files:/home/klippy/gcode_files` to `gcodes:/home/klippy/printer_data/gcodes` and from `./config:/home/klippy/.config` to `./config:/home/klippy/printer_data/config`. `moonraker_data:/home/klippy/.moonraker` was removed.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 ![Klipper Moonraker Multiarch Image CI](https://github.com/dimalo/klipper-web-control-docker/workflows/Klipper%20Moonraker%20Multiarch%20Image%20CI/badge.svg)
 
 # klipper-web-control-docker
+
+## Caution
+If you used klipper-web-control-docker before, mind the changes in `docker-compose.yml` in accordance with the changed [moonraker standard](https://moonraker.readthedocs.io/en/latest/installation/#data-folder-structure).
+Volume bindings were changed from `gcode_files:/home/klippy/gcode_files` to `gcodes:/home/klippy/printer_data/gcodes` and from `./config:/home/klippy/.config` to `./config:/home/klippy/printer_data/config`. `moonraker_data:/home/klippy/.moonraker` was removed.
+
 __Klipper with Moonraker shipped with Fluidd and/or Mainsail__
 
 - get your printer to the next level!

--- a/config/moonraker.conf
+++ b/config/moonraker.conf
@@ -2,8 +2,6 @@
 host: 0.0.0.0
 port: 7125
 enable_debug_logging: False
-config_path: /home/klippy/.config
-database_path: /home/klippy/.moonraker_database
 temperature_store_size: 1800
 gcode_store_size: 1000
 

--- a/config/moonraker.conf
+++ b/config/moonraker.conf
@@ -1,9 +1,16 @@
 [server]
 host: 0.0.0.0
 port: 7125
-enable_debug_logging: False
-config_path: /home/klippy/.config
-database_path: /home/klippy/.moonraker_database
+
+[machine]
+provider = none
+validate_service = False
+
+[file_manager]
+queue_gcode_uploads = True
+enable_object_processing = True
+
+[data_store]
 temperature_store_size: 1800
 gcode_store_size: 1000
 
@@ -24,5 +31,4 @@ trusted_clients:
 [history]
 
 [update_manager]
-enable_repo_debug: True
 enable_system_updates: False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,13 +14,13 @@ services:
       - 7125:7125
     restart: unless-stopped
     volumes:
-      - gcode_files:/home/klippy/gcode_files
+      - gcodes:/home/klippy/printer_data/gcodes
+      # mind folder permissions
       # be aware to create your own branch if you mount the config folder as it will be updated on the main branch
       # that way you can merge upstream changes to your customized configs
-      - ./config:/home/klippy/.config
-      - moonraker_data:/home/klippy/.moonraker
-      # - <<your_config_path>>:/home/klippy/.config
-      # - ./printer.cfg:/home/klippy/.config/printer.cfg
+      - ./config:/home/klippy/printer_data/config
+      # - <<your_config_path>>:/home/klippy/printer_data/config
+      # - ./printer.cfg:/home/klippy/printer_data/config/printer.cfg
     # mount serial device - take care to grant sufficient permissions to the device: <host_dev>:<container_dev>
     # put <container_dev> into your printer.cfg
     devices:
@@ -48,9 +48,9 @@ services:
   #     - gcode_files:/home/klippy/gcode_files
   #     # be aware to create your own branch if you mount the config folder as it will be updated on the main branch
   #     # that way you can merge upstream changes to your (developed) configs...
-  #     - ./config_another_printer:/home/klippy/.config
-  #     # - <<your_config_path>>:/home/klippy/.config
-  #     # - ./another_printer.cfg:/home/klippy/.config/printer.cfg
+  #     - ./config_another_printer:/home/klippy/printer_data/config
+  #     # - <<your_config_path>>:/home/klippy/printer_data/config
+  #     # - ./another_printer.cfg:/home/klippy/printer_data/config/printer.cfg
   #   # mount serial device - take care to grant sufficient permissions to the device: <host_dev>:<container_dev>
   #   # put <container_dev> into your printer.cfg
   #   devices:
@@ -91,6 +91,4 @@ services:
       # - klipper_another_printer:klipper_another_printer
 
 volumes: 
-  gcode_files:
-  moonraker_data:
-
+  gcodes:

--- a/klipper/Dockerfile
+++ b/klipper/Dockerfile
@@ -75,7 +75,9 @@ ENV LANGUAGE en_GB:en
 
 ARG USER=klippy
 ARG HOME=/home/${USER}
-ENV CONFIG_DIR=${HOME}/.config
+ARG PRINTER_DATA=${HOME}/printer_data
+ENV CONFIG_DIR=${PRINTER_DATA}/config
+ENV GCODE_DIR=${PRINTER_DATA}/gcodes
 ENV KLIPPER_VENV_DIR=${HOME}/klippy-env
 ENV MOONRAKER_VENV_DIR=${HOME}/moonraker-env
 
@@ -96,9 +98,10 @@ RUN useradd --user-group --no-log-init --shell /bin/false -m -d ${HOME} ${USER} 
 USER ${USER}
 WORKDIR ${HOME}
 
-RUN mkdir -p ${HOME}/gcode_files ${CONFIG_DIR} ${HOME}/.moonraker ${HOME}/.moonraker_database ${HOME}/.klipper_repo_backup ${HOME}/.moonraker_repo_backup
+# According to https://moonraker.readthedocs.io/en/latest/installation/#data-folder-structure
+RUN mkdir -p ${PRINTER_DATA} ${CONFIG_DIR} ${GCODE_DIR} ${PRINTER_DATA}/backup ${PRINTER_DATA}/certs ${PRINTER_DATA}/database ${PRINTER_DATA}/logs ${PRINTER_DATA}/systemd
 
-VOLUME ${HOME}/gcode_files
+VOLUME ${GCODE_DIR}
 VOLUME ${CONFIG_DIR}
 
 EXPOSE 7125

--- a/klipper/klipper.ini
+++ b/klipper/klipper.ini
@@ -1,7 +1,7 @@
 
 [program:klipper]
 user=klippy
-command=/home/klippy/klippy-env/bin/python /home/klippy/klipper/klippy/klippy.py -a /tmp/klippy_uds -l /var/log/klipper/klipper.log /home/klippy/.config/klipper.cfg
+command=/home/klippy/klippy-env/bin/python /home/klippy/klipper/klippy/klippy.py -a /tmp/klippy_uds -l /var/log/klipper/klipper.log /home/klippy/printer_data/config/klipper.cfg
 environment=USER=klippy,HOME=/home/klippy,PYTHONHOME=/home/klippy/klippy-env
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes = 0

--- a/klipper/moonraker.ini
+++ b/klipper/moonraker.ini
@@ -1,6 +1,6 @@
 [program:moonraker]
 user=klippy
-command=/home/klippy/moonraker-env/bin/python /home/klippy/moonraker/moonraker/moonraker.py -l /var/log/klipper/moonraker.log -c /home/klippy/.config/moonraker.conf
+command=/home/klippy/moonraker-env/bin/python /home/klippy/moonraker/moonraker/moonraker.py -d /home/klippy/printer_data -l /var/log/klipper/moonraker.log -c /home/klippy/printer_data/config/moonraker.conf
 environment=USER=klippy,HOME=/home/klippy
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes = 0


### PR DESCRIPTION
These changes align the docker project's folders with the moonraker defaults (see https://moonraker.readthedocs.io/en/latest/installation/#data-folder-structure).

This should solve a couple of tickets, e.g.

* https://github.com/dimalo/klipper-web-control-docker/issues/44
* https://github.com/dimalo/klipper-web-control-docker/issues/45

Note, that I altered some directory bindings, therefore some slight changes in `docker-compose.yml` are necessary.